### PR TITLE
README.rst: Fix "Title underline too short" error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 Tornado Elasticsearch Client
-===========================
+============================
 
 Tornado http client for Elasticsearch. Its goal is to provide common
 ground for all Elasticsearch-related code in tornado and provide a


### PR DESCRIPTION
Fix "Title underline too short" error that is causing PyPI to render the description as plain text rather than RST.

This is an annoying aspect of PyPI -- see https://bitbucket.org/pypa/pypi/issue/214

Before:

```
❯ rst2html.py --halt=2 README.rst > /dev/null && echo "RST OK"
README.rst:2: (WARNING/2) Title underline too short.

Tornado Elasticsearch Client
===========================
Exiting due to level-2 (WARNING) system message.
```

After:

```
❯ rst2html.py --halt=2 README.rst > /dev/null && echo "RST OK"
RST OK
```
